### PR TITLE
Add project features initialisation support

### DIFF
--- a/src/Framework/automation.ts
+++ b/src/Framework/automation.ts
@@ -88,7 +88,8 @@ export class Automation implements IAutomation {
 
             // Features first time initialization is required for
             // Related policies to work correctly (permissions, etc)
-            await releaseUpdater.initialize(project.name!);
+            await releaseUpdater.initialize(targetProject.name!);
+            await endpointUpdater.initialize(targetProject.name!, targetProject.id!);
 
             if (this.parameters.accessPermissions) {
 

--- a/src/Framework/automation.ts
+++ b/src/Framework/automation.ts
@@ -84,6 +84,10 @@ export class Automation implements IAutomation {
 
             }
 
+            // Features first time initialization is required for
+            // Related policies to work correctly (permissions, etc)
+            await releaseUpdater.initialize(project.name!);
+
             if (this.parameters.accessPermissions) {
 
                 if (project.permissions.project) {

--- a/src/Framework/automation.ts
+++ b/src/Framework/automation.ts
@@ -48,17 +48,15 @@ export class Automation implements IAutomation {
 
     public async run(): Promise<void> {
 
-        // Read configuration
-        const projects: IProject[] = await this.configurationReader.read();
-
-        // Initialize updaters
         const projectUpdater: IProjectUpdater = await this.automationFactory.createProjectUpdater();
         const buildUpdater: IBuildUpdater = await this.automationFactory.createBuildUpdater();
         const releaseUpdater: IReleaseUpdater = await this.automationFactory.createReleaseUpdater();
         const repositoryUpdater: IRepositoryUpdater = await this.automationFactory.createRepositoryUpdater();
         const workUpdater: IWorkUpdater = await this.automationFactory.createWorkUpdater();
 
-        for (const project of projects) {
+        const configuration: IProject[] = await this.configurationReader.read();
+
+        for (const project of configuration) {
 
             this.consoleLogger.log(`Configuring <${project.name}> project automation`);
 
@@ -66,7 +64,6 @@ export class Automation implements IAutomation {
 
             if (targetProject) {
 
-                // Update project
                 if (this.parameters.projectSetup) {
 
                     targetProject = await projectUpdater.updateProject(project);
@@ -75,7 +72,6 @@ export class Automation implements IAutomation {
 
             } else {
 
-                // Create project
                 if (this.parameters.projectSetup) {
 
                     targetProject = await projectUpdater.createProject(project);
@@ -88,38 +84,32 @@ export class Automation implements IAutomation {
 
             }
 
-            // Update access permissions
             if (this.parameters.accessPermissions) {
 
-                // Project
                 if (project.permissions.project) {
 
                     await projectUpdater.updatePermissions(targetProject, project.permissions.project);
 
                 }
 
-                // Build
                 if (project.permissions.build) {
 
                     await buildUpdater.updatePermissions(targetProject, project.permissions.build);
 
                 }
 
-                // Release
                 if (project.permissions.release) {
 
                     await releaseUpdater.updatePermissions(targetProject, project.permissions.release);
 
                 }
 
-                // Repository
                 if (project.permissions.repository) {
 
                     await repositoryUpdater.updatePermissions(targetProject, project.permissions.repository);
 
                 }
 
-                // Work items
                 if (project.permissions.work) {
 
                     await workUpdater.updatePermissions(targetProject, project.permissions.work);
@@ -128,14 +118,12 @@ export class Automation implements IAutomation {
 
             }
 
-            // Update branch policies
             if (this.parameters.branchPolicies) {
 
                 throw new Error("Feature not implemented");
 
             }
 
-            // Create service connections
             if (this.parameters.serviceConnections) {
 
                 throw new Error("Feature not implemented");

--- a/src/Framework/automation.ts
+++ b/src/Framework/automation.ts
@@ -18,6 +18,7 @@ import { IReleaseUpdater } from "./interfaces/updaters/releaseupdater";
 import { IRepositoryUpdater } from "./interfaces/updaters/repositoryupdater";
 import { ConfigurationReader } from "./readers/configurationreader";
 import { IWorkUpdater } from "./interfaces/updaters/workupdater";
+import { IEndpointUpdater } from "./interfaces/updaters/endpointupdater";
 
 export class Automation implements IAutomation {
 
@@ -53,6 +54,7 @@ export class Automation implements IAutomation {
         const releaseUpdater: IReleaseUpdater = await this.automationFactory.createReleaseUpdater();
         const repositoryUpdater: IRepositoryUpdater = await this.automationFactory.createRepositoryUpdater();
         const workUpdater: IWorkUpdater = await this.automationFactory.createWorkUpdater();
+        const endpointUpdater: IEndpointUpdater = await this.automationFactory.createEndpointUpdater();
 
         const configuration: IProject[] = await this.configurationReader.read();
 

--- a/src/Framework/common/azdevclient.ts
+++ b/src/Framework/common/azdevclient.ts
@@ -61,6 +61,28 @@ export class AzDevClient implements IAzDevClient {
 
     }
 
+    public async postNoRetry<T>(path: string, apiVersion?: string, body?: any, type: AzDevApiType = this.apiType): Promise<T> {
+
+        const debug = this.debugLogger.extend(this.post.name);
+
+        const url: string = this.newUrl(path, type);
+
+        debug(url);
+
+        const requestOptions: rc.IRequestOptions = {};
+
+        if (apiVersion) {
+
+            requestOptions.acceptHeader = `api-version=${apiVersion}`;
+
+        }
+
+        const response: rc.IRestResponse<any> = await this.client.create(url, body, requestOptions);
+
+        return response.result;
+
+    }
+
     @Retryable()
     public async patch<T>(path: string, apiVersion?: string, body?: any, type: AzDevApiType = this.apiType): Promise<T> {
 

--- a/src/Framework/factories/automationfactory.ts
+++ b/src/Framework/factories/automationfactory.ts
@@ -39,6 +39,10 @@ import { IWorkUpdater } from "../interfaces/updaters/workupdater";
 import { IWorkHelper } from "../interfaces/helpers/workhelper";
 import { WorkHelper } from "../helpers/workhelper";
 import { WorkUpdater } from "../updaters/workupdater";
+import { IEndpointUpdater } from "../interfaces/updaters/endpointupdater";
+import { EndpointUpdater } from "../updaters/endpointupdater";
+import { EndpointHelper } from "../helpers/endpointhelper";
+import { IEndpointHelper } from "../interfaces/helpers/endpointhelper";
 
 export class AutomationFactory implements IAutomationFactory {
 
@@ -132,6 +136,19 @@ export class AutomationFactory implements IAutomationFactory {
         const securityHelper: ISecurityHelper = new SecurityHelper(azdevClient, helper, securityMapper, this.debugLogger);
 
         return new WorkUpdater(workHelper, securityHelper, helper, this.debugLogger, this.consoleLogger);
+
+    }
+
+    public async createEndpointUpdater(): Promise<IEndpointUpdater> {
+
+        const coreApi: ca.ICoreApi = await this.apiFactory.createCoreApi();
+        const vsoClient: vc.VsoClient = await this.apiFactory.createVsoClient();
+        const azdevClient: IAzDevClient = new AzDevClient(vsoClient.restClient, AzDevApiType.Core, vsoClient.basePath, this.debugLogger);
+
+        const helper: IHelper = new Helper(this.debugLogger);
+        const endpointHelper: IEndpointHelper = new EndpointHelper(coreApi, azdevClient, this.debugLogger);
+
+        return new EndpointUpdater(endpointHelper, helper, this.debugLogger, this.consoleLogger);
 
     }
 

--- a/src/Framework/factories/automationfactory.ts
+++ b/src/Framework/factories/automationfactory.ts
@@ -141,12 +141,11 @@ export class AutomationFactory implements IAutomationFactory {
 
     public async createEndpointUpdater(): Promise<IEndpointUpdater> {
 
-        const coreApi: ca.ICoreApi = await this.apiFactory.createCoreApi();
         const vsoClient: vc.VsoClient = await this.apiFactory.createVsoClient();
         const azdevClient: IAzDevClient = new AzDevClient(vsoClient.restClient, AzDevApiType.Core, vsoClient.basePath, this.debugLogger);
 
         const helper: IHelper = new Helper(this.debugLogger);
-        const endpointHelper: IEndpointHelper = new EndpointHelper(coreApi, azdevClient, this.debugLogger);
+        const endpointHelper: IEndpointHelper = new EndpointHelper(azdevClient, this.debugLogger);
 
         return new EndpointUpdater(endpointHelper, helper, this.debugLogger, this.consoleLogger);
 

--- a/src/Framework/helpers/endpointhelper.ts
+++ b/src/Framework/helpers/endpointhelper.ts
@@ -1,0 +1,24 @@
+import Debug from "debug";
+
+import { ICoreApi } from "azure-devops-node-api/CoreApi";
+
+import { IAzDevClient } from "../interfaces/common/azdevclient";
+import { IDebugLogger } from "../interfaces/common/debuglogger";
+import { IEndpointHelper } from "../interfaces/helpers/endpointhelper";
+
+export class EndpointHelper implements IEndpointHelper {
+
+    private azdevClient: IAzDevClient;
+    private coreApi: ICoreApi;
+    private debugLogger: Debug.Debugger;
+
+    constructor(coreApi: ICoreApi, azdevClient: IAzDevClient, debugLogger: IDebugLogger) {
+
+        this.debugLogger = debugLogger.create(this.constructor.name);
+
+        this.azdevClient = azdevClient;
+        this.coreApi = coreApi;
+
+    }
+
+}

--- a/src/Framework/helpers/endpointhelper.ts
+++ b/src/Framework/helpers/endpointhelper.ts
@@ -1,7 +1,5 @@
 import Debug from "debug";
 
-import { ICoreApi } from "azure-devops-node-api/CoreApi";
-
 import { IAzDevClient } from "../interfaces/common/azdevclient";
 import { IDebugLogger } from "../interfaces/common/debuglogger";
 import { IEndpointHelper } from "../interfaces/helpers/endpointhelper";
@@ -9,15 +7,115 @@ import { IEndpointHelper } from "../interfaces/helpers/endpointhelper";
 export class EndpointHelper implements IEndpointHelper {
 
     private azdevClient: IAzDevClient;
-    private coreApi: ICoreApi;
     private debugLogger: Debug.Debugger;
 
-    constructor(coreApi: ICoreApi, azdevClient: IAzDevClient, debugLogger: IDebugLogger) {
+    constructor(azdevClient: IAzDevClient, debugLogger: IDebugLogger) {
 
         this.debugLogger = debugLogger.create(this.constructor.name);
 
         this.azdevClient = azdevClient;
-        this.coreApi = coreApi;
+
+    }
+
+    public async getServiceEndpoints(projectName: string): Promise<any[]> {
+
+        const debug = this.debugLogger.extend(this.getServiceEndpoints.name);
+
+        let results: any[] = [];
+
+        const existingServiceEndpoints: any = await this.azdevClient.get<any>(`${projectName}/_apis/serviceendpoint/endpoints`);
+
+        if (existingServiceEndpoints || existingServiceEndpoints.value.length !== 0) {
+
+            results = existingServiceEndpoints.value;
+
+        }
+
+        debug(`Found <${projectName}> project <${results.length}> service connection(s)`);
+
+        return results;
+
+    }
+
+    public async createGenericServiceEndpoint(name: string, url: string, description: string, projectName: string, projectId: string): Promise<any> {
+
+        const debug = this.debugLogger.extend(this.createGenericServiceEndpoint.name);
+
+        const body: any = {
+
+            name,
+            description,
+            type: "generic",
+            url,
+            authorization: {
+                parameters: {
+                    username: "",
+                    password: "",
+                },
+                scheme: "UsernamePassword",
+            },
+            isShared: false,
+            isReady: true,
+            serviceEndpointProjectReferences: [
+                {
+                    projectReference: {
+                        name: projectName,
+                        id: projectId,
+                    },
+                    name,
+                },
+            ],
+
+        };
+
+        const result: any = await this.azdevClient.post<any>("_apis/serviceendpoint/endpoints", "7.1-preview.4", body);
+
+        debug(result);
+
+        return result;
+
+    }
+
+    public async fakeServiceEndpoint(projectName: string, projectId: string): Promise<void> {
+
+        const debug = this.debugLogger.extend(this.fakeServiceEndpoint.name);
+
+        const body: any = {
+
+            name: "",
+            description: "",
+            type: "generic",
+            url: "",
+            authorization: {
+                parameters: {
+                    username: "",
+                    password: "",
+                },
+                scheme: "UsernamePassword",
+            },
+            isShared: false,
+            isReady: true,
+            serviceEndpointProjectReferences: [
+                {
+                    projectReference: {
+                        name: projectName,
+                        id: projectId,
+                    },
+                    name: "",
+                },
+            ],
+
+        };
+
+        try {
+
+            const result: any = await this.azdevClient.postNoRetry<any>("_apis/serviceendpoint/endpoints", "7.1-preview.4", body);
+
+        } catch {
+
+            debug("Must have initialized fake service endpoint");
+
+        }
 
     }
 

--- a/src/Framework/helpers/releasehelper.ts
+++ b/src/Framework/helpers/releasehelper.ts
@@ -21,6 +21,18 @@ export class ReleaseHelper implements IReleaseHelper {
 
     }
 
+    public async getDefinitions(projectName: string): Promise<ReleaseDefinition[]> {
+
+        const debug = this.debugLogger.extend(this.getDefinitions.name);
+
+        const result = await this.releaseApi.getReleaseDefinitions(projectName);
+
+        debug(`Found <${projectName}> project <${result.length}> definition(s)`);
+
+        return result;
+
+    }
+
     public async findDefinitionsWithArtifact(projectName: string, artifactName: string, artifactType: string): Promise<ReleaseDefinition[]> {
 
         const debug = this.debugLogger.extend(this.findDefinitionsWithArtifact.name);

--- a/src/Framework/interfaces/common/azdevclient.ts
+++ b/src/Framework/interfaces/common/azdevclient.ts
@@ -2,6 +2,7 @@ export interface IAzDevClient {
 
     get<T>(path: string, type?: AzDevApiType): Promise<T>;
     post<T>(path: string, apiVersion?: string, body?: any, type?: AzDevApiType): Promise<T>;
+    postNoRetry<T>(path: string, apiVersion?: string, body?: any, type?: AzDevApiType): Promise<T>
     patch<T>(path: string, apiVersion?: string, body?: any, type?: AzDevApiType): Promise<T>;
     put<T>(path: string, apiVersion?: string, body?: any, type?: AzDevApiType): Promise<T>;
     delete<T>(path: string, apiVersion?: string, type?: AzDevApiType): Promise<T>;

--- a/src/Framework/interfaces/factories/automationfactory.ts
+++ b/src/Framework/interfaces/factories/automationfactory.ts
@@ -1,4 +1,5 @@
 import { IBuildUpdater } from "../updaters/buildupdater";
+import { IEndpointUpdater } from "../updaters/endpointupdater";
 import { IProjectUpdater } from "../updaters/projectupdater";
 import { IReleaseUpdater } from "../updaters/releaseupdater";
 import { IRepositoryUpdater } from "../updaters/repositoryupdater";
@@ -10,5 +11,6 @@ export interface IAutomationFactory {
     createReleaseUpdater(): Promise<IReleaseUpdater>;
     createRepositoryUpdater(): Promise<IRepositoryUpdater>;
     createWorkUpdater(): Promise<IRepositoryUpdater>;
+    createEndpointUpdater(): Promise<IEndpointUpdater>;
 
 }

--- a/src/Framework/interfaces/helpers/endpointhelper.ts
+++ b/src/Framework/interfaces/helpers/endpointhelper.ts
@@ -1,0 +1,7 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+
+export interface IEndpointHelper {
+
+    //
+
+}

--- a/src/Framework/interfaces/helpers/endpointhelper.ts
+++ b/src/Framework/interfaces/helpers/endpointhelper.ts
@@ -1,7 +1,7 @@
-/* eslint-disable @typescript-eslint/no-empty-interface */
-
 export interface IEndpointHelper {
 
-    //
+    getServiceEndpoints(projectName: string): Promise<any[]>;
+    createGenericServiceEndpoint(name: string, url: string, description: string, projectName: string, projectId: string): Promise<any>;
+    fakeServiceEndpoint(projectName: string, projectId: string): Promise<void>;
 
 }

--- a/src/Framework/interfaces/helpers/releasehelper.ts
+++ b/src/Framework/interfaces/helpers/releasehelper.ts
@@ -3,6 +3,7 @@ import { TaskDefinition } from "azure-devops-node-api/interfaces/TaskAgentInterf
 
 export interface IReleaseHelper {
 
+    getDefinitions(projectName: string): Promise<ReleaseDefinition[]>;
     findDefinitionsWithArtifact(projectName: string, artifactName: string, artifactType: string): Promise<ReleaseDefinition[]>;
     findDefinitionsWithTasks(name: string, projectName: string, tasks: TaskDefinition[]): Promise<ReleaseDefinition[]>;
     findDefinitionReleasesWithTasks(definitionId: number, projectName: string, tasks: TaskDefinition[]): Promise<Release[]>;

--- a/src/Framework/interfaces/updaters/endpointupdater.ts
+++ b/src/Framework/interfaces/updaters/endpointupdater.ts
@@ -1,5 +1,5 @@
 export interface IEndpointUpdater {
 
-    initialize(projectName: string): Promise<void>;
+    initialize(projectName: string, projectId: string): Promise<void>;
 
 }

--- a/src/Framework/interfaces/updaters/endpointupdater.ts
+++ b/src/Framework/interfaces/updaters/endpointupdater.ts
@@ -1,0 +1,5 @@
+export interface IEndpointUpdater {
+
+    initialize(projectName: string): Promise<void>;
+
+}

--- a/src/Framework/interfaces/updaters/releaseupdater.ts
+++ b/src/Framework/interfaces/updaters/releaseupdater.ts
@@ -3,6 +3,7 @@ import { IReleasePermission, ITask } from "../readers/configurationreader";
 
 export interface IReleaseUpdater {
 
+    initialize(projectName: string): Promise<void>;
     removeDefinitionsArtifact(projectName: string, artifactName: string, artifactType: string, mock?: boolean): Promise<void>;
     removeDefinitionsTasks(name: string, projectName: string, task: ITask, mock?: boolean): Promise<void>;
     updateDefinitionsTasks(name: string, projectName: string, task: ITask, releases?: boolean, mock?: boolean): Promise<void>;

--- a/src/Framework/package-lock.json
+++ b/src/Framework/package-lock.json
@@ -13,7 +13,7 @@
         "ajv": "^8.11.0",
         "azure-devops-node-api": "^11.1.1",
         "debug": "^4.3.4",
-        "meow": "^10.1.3"
+        "meow": "^9.0.0"
       },
       "devDependencies": {
         "@types/chai": "^4.3.1",
@@ -35,30 +35,30 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dependencies": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
-      "integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -791,6 +791,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -799,31 +800,27 @@
       }
     },
     "node_modules/camelcase-keys": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
-      "integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
       "dependencies": {
-        "camelcase": "^6.3.0",
-        "map-obj": "^4.1.0",
-        "quick-lru": "^5.1.1",
-        "type-fest": "^1.2.1"
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/camelcase-keys/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+    "node_modules/camelcase-keys/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=6"
       }
     },
     "node_modules/chai": {
@@ -1005,14 +1002,11 @@
       }
     },
     "node_modules/decamelize": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
-      "integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decamelize-keys": {
@@ -1023,14 +1017,6 @@
         "decamelize": "^1.1.0",
         "map-obj": "^1.0.0"
       },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/decamelize-keys/node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1430,6 +1416,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -1692,14 +1679,11 @@
       }
     },
     "node_modules/indent-string": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -1892,6 +1876,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -1985,34 +1970,34 @@
       }
     },
     "node_modules/meow": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-10.1.3.tgz",
-      "integrity": "sha512-0WL7RMCPPdUTE00+GxJjL4d5Dm6eUbmAzxlzywJWiRUKCW093owmZ7/q74tH9VI91vxw9KJJNxAcvdpxb2G4iA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
       "dependencies": {
-        "@types/minimist": "^1.2.2",
-        "camelcase-keys": "^7.0.0",
-        "decamelize": "^5.0.0",
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
         "decamelize-keys": "^1.1.0",
         "hard-rejection": "^2.1.0",
         "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.2",
-        "read-pkg-up": "^8.0.0",
-        "redent": "^4.0.0",
-        "trim-newlines": "^4.0.2",
-        "type-fest": "^1.2.2",
-        "yargs-parser": "^20.2.9"
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/meow/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
       "engines": {
         "node": ">=10"
       },
@@ -2329,6 +2314,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -2343,6 +2329,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -2351,6 +2338,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/parent-module": {
@@ -2407,6 +2402,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
       "version": "1.8.0",
@@ -2509,14 +2509,11 @@
       ]
     },
     "node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/randombytes": {
@@ -2529,58 +2526,121 @@
       }
     },
     "node_modules/read-pkg": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
-      "integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
       "dependencies": {
         "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^3.0.2",
-        "parse-json": "^5.2.0",
-        "type-fest": "^1.0.1"
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/read-pkg-up": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
-      "integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
       "dependencies": {
-        "find-up": "^5.0.0",
-        "read-pkg": "^6.0.0",
-        "type-fest": "^1.0.1"
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+    },
+    "node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/read-pkg/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/readdirp": {
@@ -2596,18 +2656,15 @@
       }
     },
     "node_modules/redent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
-      "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
       "dependencies": {
-        "indent-string": "^5.0.0",
-        "strip-indent": "^4.0.0"
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/regexpp": {
@@ -2637,6 +2694,22 @@
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "dependencies": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-from": {
@@ -2865,17 +2938,14 @@
       }
     },
     "node_modules/strip-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
-      "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
       "dependencies": {
-        "min-indent": "^1.0.1"
+        "min-indent": "^1.0.0"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -2902,6 +2972,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -2921,14 +3002,11 @@
       }
     },
     "node_modules/trim-newlines": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
-      "integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/ts-node": {
@@ -3265,6 +3343,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -3275,24 +3354,24 @@
   },
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "requires": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g=="
     },
     "@babel/highlight": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
-      "integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -3845,23 +3924,23 @@
     "camelcase": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true
     },
     "camelcase-keys": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.2.tgz",
-      "integrity": "sha512-Rjs1H+A9R+Ig+4E/9oyB66UC5Mj9Xq3N//vcLf2WzgdTi/3gUu3Z9KoqmlrEG4VuuLK8wJHofxzdQXz/knhiYg==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
       "requires": {
-        "camelcase": "^6.3.0",
-        "map-obj": "^4.1.0",
-        "quick-lru": "^5.1.1",
-        "type-fest": "^1.2.1"
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
       },
       "dependencies": {
-        "type-fest": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
         }
       }
     },
@@ -3999,9 +4078,9 @@
       }
     },
     "decamelize": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
-      "integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
     },
     "decamelize-keys": {
       "version": "1.1.0",
@@ -4012,11 +4091,6 @@
         "map-obj": "^1.0.0"
       },
       "dependencies": {
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
-        },
         "map-obj": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
@@ -4330,6 +4404,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
       "requires": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -4510,9 +4585,9 @@
       "dev": true
     },
     "indent-string": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -4668,6 +4743,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
       "requires": {
         "p-locate": "^5.0.0"
       }
@@ -4740,28 +4816,28 @@
       }
     },
     "meow": {
-      "version": "10.1.3",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-10.1.3.tgz",
-      "integrity": "sha512-0WL7RMCPPdUTE00+GxJjL4d5Dm6eUbmAzxlzywJWiRUKCW093owmZ7/q74tH9VI91vxw9KJJNxAcvdpxb2G4iA==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
       "requires": {
-        "@types/minimist": "^1.2.2",
-        "camelcase-keys": "^7.0.0",
-        "decamelize": "^5.0.0",
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
         "decamelize-keys": "^1.1.0",
         "hard-rejection": "^2.1.0",
         "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.2",
-        "read-pkg-up": "^8.0.0",
-        "redent": "^4.0.0",
-        "trim-newlines": "^4.0.2",
-        "type-fest": "^1.2.2",
-        "yargs-parser": "^20.2.9"
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
       },
       "dependencies": {
         "type-fest": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+          "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="
         }
       }
     },
@@ -5010,6 +5086,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "requires": {
         "yocto-queue": "^0.1.0"
       }
@@ -5018,9 +5095,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
       "requires": {
         "p-limit": "^3.0.2"
       }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "parent-module": {
       "version": "1.0.1",
@@ -5058,6 +5141,11 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
       "version": "1.8.0",
@@ -5118,9 +5206,9 @@
       "dev": true
     },
     "quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -5132,37 +5220,91 @@
       }
     },
     "read-pkg": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
-      "integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
       "requires": {
         "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^3.0.2",
-        "parse-json": "^5.2.0",
-        "type-fest": "^1.0.1"
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
       },
       "dependencies": {
+        "hosted-git-info": {
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        },
         "type-fest": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
         }
       }
     },
     "read-pkg-up": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
-      "integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
       "requires": {
-        "find-up": "^5.0.0",
-        "read-pkg": "^6.0.0",
-        "type-fest": "^1.0.1"
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
       },
       "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
         "type-fest": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
         }
       }
     },
@@ -5176,12 +5318,12 @@
       }
     },
     "redent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
-      "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
       "requires": {
-        "indent-string": "^5.0.0",
-        "strip-indent": "^4.0.0"
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
       }
     },
     "regexpp": {
@@ -5200,6 +5342,16 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+    },
+    "resolve": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "requires": {
+        "is-core-module": "^2.9.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -5355,11 +5507,11 @@
       }
     },
     "strip-indent": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
-      "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
       "requires": {
-        "min-indent": "^1.0.1"
+        "min-indent": "^1.0.0"
       }
     },
     "strip-json-comments": {
@@ -5377,6 +5529,11 @@
         "has-flag": "^4.0.0"
       }
     },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -5393,9 +5550,9 @@
       }
     },
     "trim-newlines": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
-      "integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
     },
     "ts-node": {
       "version": "10.8.1",
@@ -5638,7 +5795,8 @@
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     }
   }
 }

--- a/src/Framework/package.json
+++ b/src/Framework/package.json
@@ -61,7 +61,7 @@
     "ajv": "^8.11.0",
     "azure-devops-node-api": "^11.1.1",
     "debug": "^4.3.4",
-    "meow": "^10.1.3"
+    "meow": "^9.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.3.1",

--- a/src/Framework/updaters/endpointupdater.ts
+++ b/src/Framework/updaters/endpointupdater.ts
@@ -30,6 +30,8 @@ export class EndpointUpdater implements IEndpointUpdater {
 
         if (results.length === 0) {
 
+            // Simply trying and failing to create new endpoint
+            // Initializes required service endpoints capabilities
             const fakeEndpoint = await this.endpointHelper.fakeServiceEndpoint(projectName, projectId);
 
         }

--- a/src/Framework/updaters/endpointupdater.ts
+++ b/src/Framework/updaters/endpointupdater.ts
@@ -1,0 +1,33 @@
+import Debug from "debug";
+
+import { IConsoleLogger } from "../interfaces/common/consolelogger";
+import { IDebugLogger } from "../interfaces/common/debuglogger";
+import { IHelper } from "../interfaces/common/helper";
+import { IEndpointHelper } from "../interfaces/helpers/endpointhelper";
+import { IEndpointUpdater } from "../interfaces/updaters/endpointupdater";
+
+export class EndpointUpdater implements IEndpointUpdater {
+
+    private endpointHelper: IEndpointHelper;
+    private helper: IHelper;
+
+    private debugLogger: Debug.Debugger;
+    private logger: IConsoleLogger;
+
+    constructor(endpointHelper: IEndpointHelper, helper: IHelper, debugLogger: IDebugLogger, consoleLogger: IConsoleLogger) {
+
+        this.debugLogger = debugLogger.create(this.constructor.name);
+        this.logger = consoleLogger;
+
+        this.endpointHelper = endpointHelper;
+        this.helper = helper;
+
+    }
+
+    public async initialize(projectName: string): Promise<void> {
+
+        // TBU
+
+    }
+
+}

--- a/src/Framework/updaters/endpointupdater.ts
+++ b/src/Framework/updaters/endpointupdater.ts
@@ -24,9 +24,15 @@ export class EndpointUpdater implements IEndpointUpdater {
 
     }
 
-    public async initialize(projectName: string): Promise<void> {
+    public async initialize(projectName: string, projectId: string): Promise<void> {
 
-        // TBU
+        const results = await this.endpointHelper.getServiceEndpoints(projectName);
+
+        if (results.length === 0) {
+
+            const fakeEndpoint = await this.endpointHelper.fakeServiceEndpoint(projectName, projectId);
+
+        }
 
     }
 

--- a/src/Framework/updaters/projectupdater.ts
+++ b/src/Framework/updaters/projectupdater.ts
@@ -62,6 +62,8 @@ export class ProjectUpdater implements IProjectUpdater {
 
         const result: OperationReference = await this.projectHelper.createProject(project.name, project.description, processTemplate, sourceControlType, projectVisibility);
 
+        await this.helper.wait(5000, 5000);
+
         const targetProject: TeamProject = await this.projectHelper.findProject(project.name);
 
         return targetProject;

--- a/src/Framework/updaters/releaseupdater.ts
+++ b/src/Framework/updaters/releaseupdater.ts
@@ -37,6 +37,8 @@ export class ReleaseUpdater implements IReleaseUpdater {
 
     public async initialize(projectName: string): Promise<void> {
 
+        // Simply getting all release definitions initializes
+        // Required classic release pipelines capabilities
         const result = this.releaseHelper.getDefinitions(projectName);
 
     }

--- a/src/Framework/updaters/releaseupdater.ts
+++ b/src/Framework/updaters/releaseupdater.ts
@@ -35,6 +35,12 @@ export class ReleaseUpdater implements IReleaseUpdater {
 
     }
 
+    public async initialize(projectName: string): Promise<void> {
+
+        const result = this.releaseHelper.getDefinitions(projectName);
+
+    }
+
     public async removeDefinitionsArtifact(projectName: string, artifactName: string, artifactType: string, mock?: boolean): Promise<void> {
 
         const debug = this.debugLogger.extend(this.removeDefinitionsArtifact.name);

--- a/src/TaskV1/helper.ts
+++ b/src/TaskV1/helper.ts
@@ -1,16 +1,16 @@
 import path from "path";
 import url from "url";
 
-import tl = require("azure-pipelines-task-lib");
+import { getBoolInput, getEndpointAuthorizationParameter, getEndpointUrl, getInput } from "azure-pipelines-task-lib";
 
 import { IEndpoint, IParameters } from "azdev-automation/interfaces/automation";
 
 export async function getEndpoint(): Promise<IEndpoint> {
 
-    const endpointName: any = tl.getInput("endpointName", true);
-    const endpointUrl: any = tl.getEndpointUrl(endpointName, true);
+    const endpointName: any = getInput("endpointName", true);
+    const endpointUrl: any = getEndpointUrl(endpointName, true);
     const accountName: any = url.parse(endpointUrl).pathname!.replace("/", "");
-    const accountToken: any = tl.getEndpointAuthorizationParameter(endpointName, "ApiToken", false);
+    const accountToken: any = getEndpointAuthorizationParameter(endpointName, "ApiToken", false);
 
     const endpoint: IEndpoint = {
 
@@ -26,12 +26,12 @@ export async function getEndpoint(): Promise<IEndpoint> {
 
 export async function getParameters(): Promise<IParameters> {
 
-    const configPath: any = tl.getInput("configPath", true);
-    const policiesPath: any = tl.getInput("policiesPath", true);
+    const configPath: any = getInput("configPath", true);
+    const policiesPath: any = getInput("policiesPath", true);
     const schemasPath: string = path.join(__dirname, "node_modules", "azdev-automation", "schemas");
 
-    const projectSetup: boolean = tl.getBoolInput("projectSetup");
-    const accessPermissions: boolean = tl.getBoolInput("accessPermissions");
+    const projectSetup: boolean = getBoolInput("projectSetup");
+    const accessPermissions: boolean = getBoolInput("accessPermissions");
 
     const parameters: IParameters = {
 

--- a/src/TaskV1/task.ts
+++ b/src/TaskV1/task.ts
@@ -1,4 +1,4 @@
-import tl = require("azure-pipelines-task-lib");
+import { TaskResult, setResult } from "azure-pipelines-task-lib";
 
 import { Automation } from "azdev-automation";
 import { IAutomation, IEndpoint, IParameters } from "azdev-automation/interfaces/automation";
@@ -16,7 +16,7 @@ async function run() {
 
     } catch (e: any) {
 
-        tl.setResult(tl.TaskResult.Failed, e.message);
+        setResult(TaskResult.Failed, e.message);
 
         console.log(e);
 


### PR DESCRIPTION
Some Azure DevOps features, such as classic pipelines and service endpoints, require some kind of magic initialization before things like permissions can be set or updated.

Adding a mechanism which makes calls to ADO APIs to trigger baked-in initialization process for:

- Classic release pipelines feature
- Service endpoints feature